### PR TITLE
Fixed key never releasing bug

### DIFF
--- a/pyVNC/Client.py
+++ b/pyVNC/Client.py
@@ -28,7 +28,7 @@ class Client(Thread):
         elif key in constants.KEYMAPPINGS:
             self.screen.protocol.key_event(constants.KEYMAPPINGS[key], down=1)
         elif type(key) == str:
-            self.screen.protocol.key_event(ord(key))
+            self.screen.protocol.key_event(ord(key), down=1)
 
         time.sleep(duration)
 
@@ -36,6 +36,24 @@ class Client(Thread):
             self.screen.protocol.key_event(constants.MODIFIERS[key], down=0)
         elif key in constants.KEYMAPPINGS:
             self.screen.protocol.key_event(constants.KEYMAPPINGS[key], down=0)
+        elif type(key) == str:
+            self.screen.protocol.key_event(ord(key), down=0)
+
+    def send_press(self, key):
+        if key in constants.MODIFIERS:
+            self.screen.protocol.key_event(constants.MODIFIERS[key], down=1)
+        elif key in constants.KEYMAPPINGS:
+            self.screen.protocol.key_event(constants.KEYMAPPINGS[key], down=1)
+        elif type(key) == str:
+            self.screen.protocol.key_event(ord(key), down=1)
+
+    def send_release(self, key):
+        if key in constants.MODIFIERS:
+            self.screen.protocol.key_event(constants.MODIFIERS[key], down=0)
+        elif key in constants.KEYMAPPINGS:
+            self.screen.protocol.key_event(constants.KEYMAPPINGS[key], down=0)
+        elif type(key) == str:
+            self.screen.protocol.key_event(ord(key), down=0)
 
     def send_mouse(self, event="Left", position=(0, 0)):
         # Left 1, Middle 2, Right 3,


### PR DESCRIPTION
I added this to fix a bug I noticed where a key (for example letter 'z') would be pressed once with `send_key()` and then would never be released again. There seemed to be a release missing for the third case of the `if`.

On my tests, I feel like the duration parameter doesn't do anything (in terms of key pressing), but I left it there anyway. From what I have tested, independently of the duration specified the `send_key()` method (with these modifications) acts like an almost instantaneous press+release. As such, it works well for menu choices and etc, but for example some in game presses that require a longer press to be detected might no occur.

Separately, I've also added the `send_press()` and `send_release()` methods, which are analogous, but give more control over when to press and when to release, also allowing more control over the duration of the press (in terms of game events, for example). 