### PR TITLE
Added duration to send_mouse in Client

### DIFF
--- a/pyVNC/Client.py
+++ b/pyVNC/Client.py
@@ -55,7 +55,7 @@ class Client(Thread):
         elif type(key) == str:
             self.screen.protocol.key_event(ord(key), down=0)
 
-    def send_mouse(self, event="Left", position=(0, 0)):
+    def send_mouse(self, event="Left", position=(0, 0), duration=0.001):
         # Left 1, Middle 2, Right 3,
         button_id = None
         if event is "Left":
@@ -66,7 +66,11 @@ class Client(Thread):
             button_id = 4
 
         self.screen.protocol.pointer_event(position[0], position[1], 0)
+        time.sleep(duration)
         self.screen.protocol.pointer_event(position[0], position[1], button_id)
+        time.sleep(duration)
+        self.screen.protocol.pointer_event(position[0], position[1], 0)
+
 
     def add_callback(self, interval, cb):
         l = task.LoopingCall(cb)


### PR DESCRIPTION
Idk if this is even maintained, but i added a fix here that was bugging me because i had a problem when communication with a vnc-server.

The current version of send_mouse is only triggering "on-mouse-down"-Events on the server, but not "on-mouse-release" because it never releases the button. Also sometimes a delay between the actions is needed (depending on the vnc server)

So if anyone has the issue that a pointer-event is not really recognized, maybe try to add this to the Client-Code.